### PR TITLE
CPI-53: Added Java API to allow fetching all stream IDs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Java API to retrieve all stream IDs (active and inactive ones)
 
 ## [2.0.0-M39] - 2019-06-19
 ### Changed

--- a/event-sourcing/event-repository/event-repository-jdbc/src/main/java/uk/gov/justice/services/eventsourcing/repository/jdbc/EventRepository.java
+++ b/event-sourcing/event-repository/event-repository-jdbc/src/main/java/uk/gov/justice/services/eventsourcing/repository/jdbc/EventRepository.java
@@ -29,7 +29,7 @@ public interface EventRepository {
     /**
      * Get a stream of event envelopes from a given position, ordered by position ascending.
      *
-     * @param streamId   the id of the stream to retrieve
+     * @param streamId the id of the stream to retrieve
      * @param position the position to read the stream from
      * @return the stream of envelopes. Never returns null.
      */
@@ -39,7 +39,7 @@ public interface EventRepository {
      * Get a stream of envelopes from a given version, ordered by sequence id. The stream is paged
      * for efficiency
      *
-     * @param streamId   the id of the stream to retrieve
+     * @param streamId the id of the stream to retrieve
      * @param position the sequence id to read the stream from
      * @param pageSize the size of the result set page.
      * @return the stream of envelopes. Never returns null.
@@ -59,8 +59,7 @@ public interface EventRepository {
      * Returns the position for the given stream id.
      *
      * @param streamId id of the stream.
-     * @return position for the stream.  Returns 0 if stream doesn't exist. Never returns
-     * null.
+     * @return position for the stream.  Returns 0 if stream doesn't exist. Never returns null.
      */
     long getStreamSize(final UUID streamId);
 
@@ -86,6 +85,13 @@ public interface EventRepository {
      * @return the Stream of active streamIds
      */
     Stream<UUID> getAllActiveStreamIds();
+
+    /**
+     * Returns Stream of all streamIds (includes active / inactive ones)
+     *
+     * @return the Stream of streamIds (includes active / inactive ones)
+     */
+    Stream<UUID> getAllStreamIds();
 
     /**
      * Clears all of the events from a stream.
@@ -126,8 +132,7 @@ public interface EventRepository {
     long getStreamPosition(final UUID streamId);
 
     /**
-     * Returns stream of EventStreamMetadata
-     * ascending
+     * Returns stream of EventStreamMetadata ascending
      *
      * @return the stream of envelope streams
      */

--- a/event-sourcing/event-repository/event-repository-jdbc/src/main/java/uk/gov/justice/services/eventsourcing/repository/jdbc/JdbcBasedEventRepository.java
+++ b/event-sourcing/event-repository/event-repository-jdbc/src/main/java/uk/gov/justice/services/eventsourcing/repository/jdbc/JdbcBasedEventRepository.java
@@ -119,6 +119,12 @@ public class JdbcBasedEventRepository implements EventRepository {
                 .map(EventStream::getStreamId);
     }
 
+    @Override
+    public Stream<UUID> getAllStreamIds() {
+        return eventStreamJdbcRepository.findAll()
+                .map(EventStream::getStreamId);
+    }
+
     private Stream<Stream<JsonEnvelope>> getStreams(final Stream<UUID> streamIds) {
         return streamIds
                 .map(id -> {

--- a/event-sourcing/event-repository/event-repository-jdbc/src/test/java/uk/gov/justice/services/eventsourcing/repository/jdbc/JdbcBasedEventRepositoryTest.java
+++ b/event-sourcing/event-repository/event-repository-jdbc/src/test/java/uk/gov/justice/services/eventsourcing/repository/jdbc/JdbcBasedEventRepositoryTest.java
@@ -225,6 +225,24 @@ public class JdbcBasedEventRepositoryTest {
         final UUID streamId2 = UUID.fromString("4b4e80a0-76f7-476c-b75b-527e38fb252e");
         final UUID streamId3 = UUID.fromString("4b4e80a0-76f7-476c-b75b-527e38fb253e");
 
+        when(eventStreamJdbcRepository.findActive()).thenReturn(of(buildEventStreamFor(streamId1, 1L), buildEventStreamFor(streamId2, 2L), buildEventStreamFor(streamId3, 3L)));
+
+        final Stream<UUID> allActiveStreamIds = jdbcBasedEventRepository.getAllActiveStreamIds();
+
+        final List<UUID> streamIds = allActiveStreamIds.collect(toList());
+        assertThat(streamIds, hasSize(3));
+
+        assertThat(streamIds.get(0), is(streamId1));
+        assertThat(streamIds.get(1), is(streamId2));
+        assertThat(streamIds.get(2), is(streamId3));
+    }
+
+    @Test
+    public void shouldGetAllStreamOfStreamIds() throws Exception {
+        final UUID streamId1 = UUID.fromString("4b4e80a0-76f7-476c-b75b-527e38fb251e");
+        final UUID streamId2 = UUID.fromString("4b4e80a0-76f7-476c-b75b-527e38fb252e");
+        final UUID streamId3 = UUID.fromString("4b4e80a0-76f7-476c-b75b-527e38fb253e");
+
         when(eventStreamJdbcRepository.findAll()).thenReturn(of(buildEventStreamFor(streamId1, 1L), buildEventStreamFor(streamId2, 2L), buildEventStreamFor(streamId3, 3L)));
 
         final Stream<UUID> allStreamIds = jdbcBasedEventRepository.getAllStreamIds();

--- a/event-sourcing/event-repository/event-repository-jdbc/src/test/java/uk/gov/justice/services/eventsourcing/repository/jdbc/JdbcBasedEventRepositoryTest.java
+++ b/event-sourcing/event-repository/event-repository-jdbc/src/test/java/uk/gov/justice/services/eventsourcing/repository/jdbc/JdbcBasedEventRepositoryTest.java
@@ -225,11 +225,11 @@ public class JdbcBasedEventRepositoryTest {
         final UUID streamId2 = UUID.fromString("4b4e80a0-76f7-476c-b75b-527e38fb252e");
         final UUID streamId3 = UUID.fromString("4b4e80a0-76f7-476c-b75b-527e38fb253e");
 
-        when(eventStreamJdbcRepository.findActive()).thenReturn(of(buildEventStreamFor(streamId1, 1L), buildEventStreamFor(streamId2, 2L), buildEventStreamFor(streamId3, 3L)));
+        when(eventStreamJdbcRepository.findAll()).thenReturn(of(buildEventStreamFor(streamId1, 1L), buildEventStreamFor(streamId2, 2L), buildEventStreamFor(streamId3, 3L)));
 
-        final Stream<UUID> allActiveStreamIds = jdbcBasedEventRepository.getAllActiveStreamIds();
+        final Stream<UUID> allStreamIds = jdbcBasedEventRepository.getAllStreamIds();
 
-        final List<UUID> streamIds = allActiveStreamIds.collect(toList());
+        final List<UUID> streamIds = allStreamIds.collect(toList());
         assertThat(streamIds, hasSize(3));
 
         assertThat(streamIds.get(0), is(streamId1));


### PR DESCRIPTION
- (active and inactive ones) in a streaming manner
- this is required for the transformation tool process and anonymise all streams