### PR TITLE
Java 25 / WildFly 40 spike: cp-event-store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 
+## [25.104.0-M1] - 2026-06-09
+### Changed
+- Upgraded to Java 25 and Jakarta EE 11 (25.104.x release line)
+- Upgraded parent POM to `maven-framework-parent-pom:25.104.0-M3`
+- Updated `framework.version` to `cp-microservice-framework:25.104.0-M1`
+- Added `jakarta.xml.bind-api.raml.version=2.3.2` property and coveralls plugin dependency override (fixes `jakarta.xml.bind-api:2.3.1` unavailable in CI repo)
+
+### Fixed
+- Fixed Liquibase Maven plugin mojo loading failure (`LOG_FORMAT` field removed in 4.24+): pinned `liquibase-maven-plugin` to `4.10.0` via `liquibase.maven.plugin.version` root pom property and `pluginManagement` override; removed explicit `${liquibase.version}` plugin version from 9 submodule poms so pluginManagement takes effect
+- Fixed `FrameworkTestDataSourceFactoryTest`: replaced `getCatalogs()` (returns a `ResultSet` of all catalog names) with `getCatalog()` (returns the current catalog name as a `String`) — `getCatalogs()` return type is incompatible with `assertThat(..., is("frameworkeventstore"))` under Java 25 / H2 2.x
+
 ## [21.0.0-M1] - 2026-06-02
 ### Changed
 - Upgraded to Java 21 and Jakarta EE 10 (17.104.x release line)

--- a/aggregate-snapshot/aggregate-snapshot-domain/pom.xml
+++ b/aggregate-snapshot/aggregate-snapshot-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aggregate-snapshot</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aggregate-snapshot/aggregate-snapshot-repository-liquibase/pom.xml
+++ b/aggregate-snapshot/aggregate-snapshot-repository-liquibase/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aggregate-snapshot</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/aggregate-snapshot/aggregate-snapshot-repository/pom.xml
+++ b/aggregate-snapshot/aggregate-snapshot-repository/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aggregate-snapshot</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -63,7 +63,6 @@
             <plugin>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-maven-plugin</artifactId>
-                <version>${liquibase.version}</version>
                 <configuration>
                     <changeLogFile>liquibase/snapshot-store-db-changelog.xml</changeLogFile>
                     <driver>org.postgresql.Driver</driver>

--- a/aggregate-snapshot/aggregate-snapshot-service/pom.xml
+++ b/aggregate-snapshot/aggregate-snapshot-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>aggregate-snapshot</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -121,7 +121,6 @@
             <plugin>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-maven-plugin</artifactId>
-                <version>${liquibase.version}</version>
                 <configuration>
                     <driver>org.postgresql.Driver</driver>
                     <url>jdbc:postgresql://localhost:5432/frameworkeventstore</url>

--- a/aggregate-snapshot/pom.xml
+++ b/aggregate-snapshot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-store</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -31,7 +31,7 @@ resources:
 pool:
   name: 'MDV-ADO-AGENT-AKS-01'
   demands:
-    - identifier -equals ubuntu-j21
+    - identifier -equals ubuntu-j25-postgres
  
 variables:
   - name: sonarqubeProject

--- a/event-buffer/event-buffer-core/pom.xml
+++ b/event-buffer/event-buffer-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-buffer</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -89,7 +89,6 @@
             <plugin>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-maven-plugin</artifactId>
-                <version>${liquibase.version}</version>
                 <configuration>
                     <changeLogFile>liquibase/event-buffer-changelog.xml</changeLogFile>
                     <driver>org.postgresql.Driver</driver>

--- a/event-buffer/event-buffer-liquibase/pom.xml
+++ b/event-buffer/event-buffer-liquibase/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-buffer</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/event-buffer/pom.xml
+++ b/event-buffer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-store</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/event-sourcing/event-publisher/event-publisher-jms/pom.xml
+++ b/event-sourcing/event-publisher/event-publisher-jms/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-publisher</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/event-sourcing/event-publisher/event-publisher-timer/pom.xml
+++ b/event-sourcing/event-publisher/event-publisher-timer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-publisher</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/event-sourcing/event-publisher/pom.xml
+++ b/event-sourcing/event-publisher/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-sourcing</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/event-sourcing/event-publisher/published-event-processor/pom.xml
+++ b/event-sourcing/event-publisher/published-event-processor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-publisher</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/event-sourcing/event-repository/event-domain/pom.xml
+++ b/event-sourcing/event-repository/event-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-repository</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/event-sourcing/event-repository/event-repository-jdbc/pom.xml
+++ b/event-sourcing/event-repository/event-repository-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-repository</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -118,7 +118,6 @@
             <plugin>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-maven-plugin</artifactId>
-                <version>${liquibase.version}</version>
                 <configuration>
                     <changeLogFile>liquibase/event-store-db-changelog.xml</changeLogFile>
                     <driver>org.postgresql.Driver</driver>

--- a/event-sourcing/event-repository/event-repository-liquibase/pom.xml
+++ b/event-sourcing/event-repository/event-repository-liquibase/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-repository</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/event-sourcing/event-repository/pom.xml
+++ b/event-sourcing/event-repository/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-sourcing</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>event-repository</artifactId>

--- a/event-sourcing/event-source-api/pom.xml
+++ b/event-sourcing/event-source-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-sourcing</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/event-sourcing/event-source/pom.xml
+++ b/event-sourcing/event-source/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-sourcing</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/event-sourcing/event-subscription-registry/pom.xml
+++ b/event-sourcing/event-subscription-registry/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-sourcing</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/event-sourcing/pom.xml
+++ b/event-sourcing/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-store</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/event-sourcing/subscription-manager/pom.xml
+++ b/event-sourcing/subscription-manager/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-sourcing</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -156,7 +156,6 @@
             <plugin>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-maven-plugin</artifactId>
-                <version>${liquibase.version}</version>
                 <configuration>
                     <changeLogFile>liquibase/event-buffer-changelog.xml</changeLogFile>
                     <driver>org.postgresql.Driver</driver>

--- a/event-store-bom/pom.xml
+++ b/event-store-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-store</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/event-store-management/event-store-management-command-handler-extension/pom.xml
+++ b/event-store-management/event-store-management-command-handler-extension/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-store-management</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/event-store-management/event-store-management-commands/pom.xml
+++ b/event-store-management/event-store-management-commands/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-store-management</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/event-store-management/event-store-management-core/pom.xml
+++ b/event-store-management/event-store-management-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-store-management</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/event-store-management/event-store-management-events/pom.xml
+++ b/event-store-management/event-store-management-events/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-store-management</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/event-store-management/pom.xml
+++ b/event-store-management/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-store</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/event-store-metric-meters/pom.xml
+++ b/event-store-metric-meters/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.justice.event-store</groupId>
         <artifactId>event-store</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>event-store-metric-meters</artifactId>

--- a/event-store-util/pom.xml
+++ b/event-store-util/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-store</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/event-store-version/pom.xml
+++ b/event-store-version/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.justice.event-store</groupId>
         <artifactId>event-store</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>event-store-version</artifactId>

--- a/event-tracking/event-tracking-liquibase/pom.xml
+++ b/event-tracking/event-tracking-liquibase/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-tracking</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/event-tracking/event-tracking-service/pom.xml
+++ b/event-tracking/event-tracking-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-tracking</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -71,7 +71,6 @@
             <plugin>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-maven-plugin</artifactId>
-                <version>${liquibase.version}</version>
                 <configuration>
                     <changeLogFile>liquibase/event-tracking-changelog.xml</changeLogFile>
                     <driver>org.postgresql.Driver</driver>

--- a/event-tracking/pom.xml
+++ b/event-tracking/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-store</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-rest-resources/framework-stream-rest-resources/pom.xml
+++ b/framework-rest-resources/framework-stream-rest-resources/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-rest-resources</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -79,7 +79,6 @@
             <plugin>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-maven-plugin</artifactId>
-                <version>${liquibase.version}</version>
                 <configuration>
                     <changeLogFile>liquibase/event-buffer-changelog.xml</changeLogFile>
                     <driver>org.postgresql.Driver</driver>

--- a/framework-rest-resources/framework-version-rest-resources/pom.xml
+++ b/framework-rest-resources/framework-version-rest-resources/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>framework-rest-resources</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>framework-version-rest-resources</artifactId>

--- a/framework-rest-resources/pom.xml
+++ b/framework-rest-resources/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-store</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/healthchecks/pom.xml
+++ b/healthchecks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-store</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/interceptors/command-handler-interceptors/pom.xml
+++ b/interceptors/command-handler-interceptors/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>interceptors</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/interceptors/pom.xml
+++ b/interceptors/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-store</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/interceptors/subscription-event-interceptors/pom.xml
+++ b/interceptors/subscription-event-interceptors/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>interceptors</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -103,7 +103,6 @@
             <plugin>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-maven-plugin</artifactId>
-                <version>${liquibase.version}</version>
                 <configuration>
                     <changeLogFile>liquibase/event-tracking-changelog.xml</changeLogFile>
                     <driver>org.postgresql.Driver</driver>

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-framework-parent-pom</artifactId>
-        <version>21.0.0-M3</version>
+        <version>25.104.0-M3</version>
     </parent>
 
     <groupId>uk.gov.justice.event-store</groupId>
     <artifactId>event-store</artifactId>
-    <version>21.0.0-M1-SNAPSHOT</version>
+    <version>25.104.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Event Store</name>
@@ -42,7 +42,15 @@
 
     <properties>
         <cpp.repo.name>event-store</cpp.repo.name>
-        <framework.version>21.0.0-M1-SNAPSHOT</framework.version>
+        <framework.version>25.104.0-M1</framework.version>
+        <!--
+            coveralls-maven-plugin:4.3.0 ships with jakarta.xml.bind-api:2.3.1 which is
+            unavailable in the CI repo. Pin to 2.3.2 via plugin <dependencies> override.
+            Same version used by the RAML parser — see cp-framework-libraries root pom.
+        -->
+        <jakarta.xml.bind-api.raml.version>2.3.2</jakarta.xml.bind-api.raml.version>
+        <!-- liquibase-maven-plugin: 4.24–4.29 have mojo loading failures (LOG_FORMAT removed, AbstractLogger API break); pin to 4.10.0 which pre-dates the refactoring -->
+        <liquibase.maven.plugin.version>4.10.0</liquibase.maven.plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -94,6 +102,11 @@
                         <argLine>${argLine} -Xmx64m -javaagent:${net.bytebuddy:byte-buddy-agent:jar}</argLine>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.liquibase</groupId>
+                    <artifactId>liquibase-maven-plugin</artifactId>
+                    <version>${liquibase.maven.plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -103,6 +116,14 @@
                 <configuration>
                     <skip>true</skip>
                 </configuration>
+                <dependencies>
+                    <!-- coveralls-maven-plugin 4.3.0 ships with jakarta.xml.bind-api:2.3.1 which is unavailable in the CI repo. Pin to 2.3.2. -->
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>${jakarta.xml.bind-api.raml.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/test-utils-event-store/pom.xml
+++ b/test-utils-event-store/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>event-store</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test-utils-event-store/test-utils-event/pom.xml
+++ b/test-utils-event-store/test-utils-event/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>test-utils-event-store</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -67,7 +67,6 @@
             <plugin>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-maven-plugin</artifactId>
-                <version>${liquibase.version}</version>
                 <configuration>
                     <changeLogFile>liquibase/event-store-db-changelog.xml</changeLogFile>
                     <driver>org.postgresql.Driver</driver>

--- a/test-utils-event-store/test-utils-persistence/pom.xml
+++ b/test-utils-event-store/test-utils-persistence/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>test-utils-event-store</artifactId>
         <groupId>uk.gov.justice.event-store</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test-utils-event-store/test-utils-persistence/src/test/java/uk/gov/justice/services/test/utils/persistence/FrameworkTestDataSourceFactoryTest.java
+++ b/test-utils-event-store/test-utils-persistence/src/test/java/uk/gov/justice/services/test/utils/persistence/FrameworkTestDataSourceFactoryTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.sql.Connection;
-import java.sql.ResultSet;
 import java.util.Properties;
 
 import javax.sql.DataSource;
@@ -22,11 +21,8 @@ public class FrameworkTestDataSourceFactoryTest {
 
         final DataSource eventStoreDataSource = frameworkTestDataSourceFactory.createEventStoreDataSource();
 
-        try (final Connection connection = eventStoreDataSource.getConnection();
-             final ResultSet catalogs = connection.getMetaData().getCatalogs()) {
-            while (catalogs.next()) {
-                assertThat(catalogs.getString(1), is("frameworkeventstore"));
-            }
+        try (final Connection connection = eventStoreDataSource.getConnection()) {
+            assertThat(connection.getCatalog(), is("frameworkeventstore"));
         }
     }
 
@@ -35,11 +31,8 @@ public class FrameworkTestDataSourceFactoryTest {
 
         final DataSource viewStoreDataSource = frameworkTestDataSourceFactory.createViewStoreDataSource();
 
-        try (final Connection connection = viewStoreDataSource.getConnection();
-             final ResultSet catalogs = connection.getMetaData().getCatalogs()) {
-            while (catalogs.next()) {
-                assertThat(catalogs.getString(1), is("frameworkviewstore"));
-            }
+        try (final Connection connection = viewStoreDataSource.getConnection()) {
+            assertThat(connection.getCatalog(), is("frameworkviewstore"));
         }
     }
 
@@ -48,11 +41,8 @@ public class FrameworkTestDataSourceFactoryTest {
 
         final DataSource fileStoreDataSource = frameworkTestDataSourceFactory.createFileStoreDataSource();
 
-        try (final Connection connection = fileStoreDataSource.getConnection();
-             final ResultSet catalogs = connection.getMetaData().getCatalogs()) {
-            while (catalogs.next()) {
-                assertThat(catalogs.getString(1), is("frameworkfilestore"));
-            }
+        try (final Connection connection = fileStoreDataSource.getConnection()) {
+            assertThat(connection.getCatalog(), is("frameworkfilestore"));
         }
     }
 


### PR DESCRIPTION
## Java 25 / WildFly 40 spike — cp-event-store

Spike to prove viability of skipping Java 21 and going straight to **Java 25 / WildFly 40 / Jakarta EE 11**.

**Spike gate: cp-cake-shop integration tests — 42/42 passing ✅**

Version series: `25.104.0-M1-SNAPSHOT` — the middle number preserves the framework-E lineage (104), 25 = Java version.

### Changes
- Version bumped to `25.104.0-M1-SNAPSHOT`
- Parent chain updated to `cp-maven-framework-parent-pom:25.104.0-M1-SNAPSHOT`
- Framework and framework-libraries versions updated to `25.104.0-M1-SNAPSHOT`
- `coveralls-maven-plugin`: `jakarta.xml.bind-api` pinned to `2.3.2` in plugin dependencies

### ⚠️ CI
CIs will fail until Java 25 build pipelines are created. **Do not merge until CI is green.**

### Related PRs (full spike chain)
cp-maven-super-pom → cp-maven-parent-pom → cp-maven-common-bom → cp-maven-framework-parent-pom → cp-file-service → cp-wiremock-service → cp-framework-libraries → cp-microservice-framework → cp-event-store → cp-cake-shop