### PR TITLE
Remove liquibase.hub.mode property removed in Liquibase 4.12.0

### DIFF
--- a/aggregate-snapshot/aggregate-snapshot-repository-liquibase/src/main/resources/liquibase.properties
+++ b/aggregate-snapshot/aggregate-snapshot-repository-liquibase/src/main/resources/liquibase.properties
@@ -1,5 +1,4 @@
 changelog-file: liquibase/snapshot-store-db-changelog.xml
-liquibase.hub.mode: off
 liquibase.headless: true
 
 # Stop liquibase collecting anonymous analytics should we ever upgrade to liquibase 4.30.0 or greater

--- a/event-buffer/event-buffer-liquibase/src/main/resources/liquibase.properties
+++ b/event-buffer/event-buffer-liquibase/src/main/resources/liquibase.properties
@@ -1,5 +1,4 @@
 changelog-file: liquibase/event-buffer-changelog.xml
-liquibase.hub.mode: off
 liquibase.headless: true
 
 # Stop liquibase collecting anonymous analytics should we ever upgrade to liquibase 4.30.0 or greater

--- a/event-sourcing/event-repository/event-repository-liquibase/src/main/resources/liquibase.properties
+++ b/event-sourcing/event-repository/event-repository-liquibase/src/main/resources/liquibase.properties
@@ -1,5 +1,4 @@
 changelog-file: liquibase/event-store-db-changelog.xml
-liquibase.hub.mode: off
 liquibase.headless: true
 
 # Stop liquibase collecting anonymous analytics should we ever upgrade to liquibase 4.30.0 or greater

--- a/event-tracking/event-tracking-liquibase/src/main/resources/liquibase.properties
+++ b/event-tracking/event-tracking-liquibase/src/main/resources/liquibase.properties
@@ -1,5 +1,4 @@
 changelog-file: liquibase/event-tracking-changelog.xml
-liquibase.hub.mode: off
 liquibase.headless: true
 
 # Stop liquibase collecting anonymous analytics should we ever upgrade to liquibase 4.30.0 or greater


### PR DESCRIPTION
## Summary

- `liquibase.hub.mode` was removed in Liquibase 4.12.0
- Any Liquibase JAR bundling 4.12.0+ rejects it under strict checking and exits non-zero
- This causes the Kubernetes pre-install Liquibase job to time out at 900s
- Affects: `event-repository-liquibase`, `aggregate-snapshot-repository-liquibase`, `event-buffer-liquibase`, `event-tracking-liquibase`

## Fix

Remove `liquibase.hub.mode: off` from all four `liquibase.properties` files in this project.

## Test plan

- [ ] Build passes: `mvn clean install`
- [ ] Pipeline re-run confirms Liquibase steps succeed