### PR TITLE
Add EntityManagerFlushInterceptor presence verifier; consume framework M4 (M5 release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 
+## [25.104.0-M5] - 2026-07-27
+### Added
+- **Fail-fast guard for the event-stream self-healing `EntityManagerFlushInterceptor`** (`subscription-manager`,
+  `EntityManagerFlushInterceptorPresenceVerifier`, a CDI `Extension` running at `AfterDeploymentValidation`).
+  When event-stream self-healing is enabled, it verifies the `EntityManagerFlushInterceptor` is present on every
+  event-listener interceptor chain (the standard `EVENT_LISTENER` and any custom `*_EVENT_LISTENER` component) and
+  **fails the deployment** (`addDeploymentProblem`) with a plain-English message if it is missing.
+  **Why:** the flush interceptor forces each event-listener's DB changes to flush *within* the handler, so a DB
+  error is caught by self-healing, recorded in the error tables, and retried; without it the error only fires at
+  container commit — invisible to self-healing — and failing events are silently dropped. It had been accidentally
+  dropped more than once (a persistence dependency reworked off the classpath; a custom event-listener component
+  building its own chain), with no visible symptom until error capture was needed. The interceptor is matched by
+  fully-qualified **class name**, so the check still runs (and fails) even when the module providing it has been
+  dropped from the deployment. The check is gated on `isEventStreamSelfHealingEnabled()`: with self-healing off,
+  the interceptor is intentionally absent and no verification runs.
+
+### Changed
+- Bumped parent `maven-framework-parent-pom` to `25.104.0-M8` and `framework.version` (microservice-framework) to `25.104.0-M4` — picks up Jackson `2.21.5` (**CVE-2026-54515**) and the `org.junit:junit-bom` import via `maven-common-bom` M6.
+
 ## [25.104.0-M4] - 2026-07-07
 ### Changed
 - Updated `framework.version` to `25.104.0-M3` — picks up the new `persistence-jpa` module (the relocated event-stream self-healing `EntityManagerFlushInterceptor` + `EntityManagerProducer`) and the removal of the orphaned `persistence-deltaspike`

--- a/event-sourcing/subscription-manager/src/main/java/uk/gov/justice/services/event/sourcing/subscription/error/startup/EntityManagerFlushInterceptorMissingException.java
+++ b/event-sourcing/subscription-manager/src/main/java/uk/gov/justice/services/event/sourcing/subscription/error/startup/EntityManagerFlushInterceptorMissingException.java
@@ -1,0 +1,13 @@
+package uk.gov.justice.services.event.sourcing.subscription.error.startup;
+
+/**
+ * Thrown at deployment time when event stream self-healing is enabled but one or more event-listener
+ * interceptor chains are missing the {@code EntityManagerFlushInterceptor}. Registered as a CDI deployment
+ * problem so WildFly fails the deployment rather than starting a context whose error handling is silently broken.
+ */
+public class EntityManagerFlushInterceptorMissingException extends RuntimeException {
+
+    public EntityManagerFlushInterceptorMissingException(final String message) {
+        super(message);
+    }
+}

--- a/event-sourcing/subscription-manager/src/main/java/uk/gov/justice/services/event/sourcing/subscription/error/startup/EntityManagerFlushInterceptorPresenceVerifier.java
+++ b/event-sourcing/subscription-manager/src/main/java/uk/gov/justice/services/event/sourcing/subscription/error/startup/EntityManagerFlushInterceptorPresenceVerifier.java
@@ -1,0 +1,140 @@
+package uk.gov.justice.services.event.sourcing.subscription.error.startup;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+import static uk.gov.justice.services.core.annotation.Component.EVENT_LISTENER;
+
+import uk.gov.justice.services.common.configuration.errors.event.EventErrorHandlingConfiguration;
+import uk.gov.justice.services.core.interceptor.InterceptorChainEntryProvider;
+import uk.gov.justice.services.framework.utilities.cdi.CdiInstanceResolver;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.AfterDeploymentValidation;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.Extension;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Fails the deployment if event stream self-healing is enabled but the {@code EntityManagerFlushInterceptor}
+ * is absent from an event-listener interceptor chain.
+ *
+ * <p>The flush interceptor forces Hibernate insert/update errors to surface <em>inside</em> the interceptor
+ * chain, where the self-healing error handling can catch and record them. If it is missing, those errors only
+ * fire at container commit (outside application code) and are never recorded — silently breaking error capture.
+ * It has been accidentally dropped more than once (a persistence dependency reworked off the classpath, or a
+ * custom event-listener component that builds its own chain), and the failure is invisible until an error needs
+ * to be captured and isn't. This verifier turns that silent gap into a hard deployment failure.</p>
+ *
+ * <p>The interceptor is matched by fully-qualified <strong>class name</strong>, deliberately, so this check still
+ * runs (and fails) when the module providing the interceptor has been dropped from the deployment entirely.</p>
+ *
+ * <p>The check is gated on {@link EventErrorHandlingConfiguration#isEventStreamSelfHealingEnabled()}: when
+ * self-healing is off the flush interceptor is intentionally not on the chain, so no verification is performed.</p>
+ */
+public class EntityManagerFlushInterceptorPresenceVerifier implements Extension {
+
+    @VisibleForTesting
+    static final String ENTITY_MANAGER_FLUSH_INTERCEPTOR_CLASS_NAME =
+            "uk.gov.justice.services.persistence.EntityManagerFlushInterceptor";
+
+    @VisibleForTesting
+    static final String MISSING_INTERCEPTOR_MESSAGE_TEMPLATE = """
+            Deployment stopped: event stream self-healing (error handling) is switched ON for this context, but the \
+            EntityManagerFlushInterceptor is not on the interceptor chain for event-listener component(s): %s.
+
+            Why this is fatal: this interceptor forces each event-listener's database changes to be written while the \
+            event is still being handled. That is what lets self-healing catch a database error, record it in the error \
+            tables, and retry the event. Without it, database errors only happen later - after the handler has finished - \
+            where self-healing cannot see them, so failing events are silently dropped instead of recorded and retried.
+
+            How to fix: ensure the framework 'persistence-jpa' module is on this deployment, and that every \
+            event-listener component registers the interceptor (%s) on its chain. If self-healing is intentionally off, \
+            this check does not run.""";
+
+    private final CdiInstanceResolver cdiInstanceResolver;
+    private final Logger logger;
+
+    // Empty constructor required for CDI
+    public EntityManagerFlushInterceptorPresenceVerifier() {
+        this(new CdiInstanceResolver(), LoggerFactory.getLogger(EntityManagerFlushInterceptorPresenceVerifier.class));
+    }
+
+    @VisibleForTesting
+    public EntityManagerFlushInterceptorPresenceVerifier(final CdiInstanceResolver cdiInstanceResolver, final Logger logger) {
+        this.cdiInstanceResolver = cdiInstanceResolver;
+        this.logger = logger;
+    }
+
+    public void afterDeploymentValidation(@Observes final AfterDeploymentValidation event, final BeanManager beanManager) {
+
+        final EventErrorHandlingConfiguration eventErrorHandlingConfiguration = cdiInstanceResolver.getInstanceOf(
+                EventErrorHandlingConfiguration.class,
+                beanManager);
+
+        if (!eventErrorHandlingConfiguration.isEventStreamSelfHealingEnabled()) {
+            return;
+        }
+
+        final Map<String, Set<String>> interceptorClassNamesByComponent = interceptorClassNamesByComponent(beanManager);
+
+        final List<String> componentsMissingFlushInterceptor = componentsMissingFlushInterceptor(interceptorClassNamesByComponent);
+
+        if (!componentsMissingFlushInterceptor.isEmpty()) {
+            final String message = format(
+                    MISSING_INTERCEPTOR_MESSAGE_TEMPLATE,
+                    String.join(", ", componentsMissingFlushInterceptor),
+                    ENTITY_MANAGER_FLUSH_INTERCEPTOR_CLASS_NAME);
+
+            logger.error(message);
+            event.addDeploymentProblem(new EntityManagerFlushInterceptorMissingException(message));
+        }
+    }
+
+    private Map<String, Set<String>> interceptorClassNamesByComponent(final BeanManager beanManager) {
+
+        final Map<String, Set<String>> interceptorClassNamesByComponent = new HashMap<>();
+
+        for (final Bean<?> providerBean : beanManager.getBeans(InterceptorChainEntryProvider.class)) {
+            final CreationalContext<?> creationalContext = beanManager.createCreationalContext(providerBean);
+            final InterceptorChainEntryProvider provider = (InterceptorChainEntryProvider) beanManager.getReference(
+                    providerBean,
+                    InterceptorChainEntryProvider.class,
+                    creationalContext);
+
+            final Set<String> interceptorClassNames = interceptorClassNamesByComponent.computeIfAbsent(
+                    provider.component(),
+                    component -> new HashSet<>());
+
+            provider.interceptorChainTypes().forEach(entry ->
+                    interceptorClassNames.add(entry.getInterceptorType().getName()));
+        }
+
+        return interceptorClassNamesByComponent;
+    }
+
+    /**
+     * Every component whose name identifies it as an event listener (the standard {@code EVENT_LISTENER} and
+     * any custom {@code *_EVENT_LISTENER}) must carry the flush interceptor when self-healing is enabled.
+     */
+    @VisibleForTesting
+    List<String> componentsMissingFlushInterceptor(final Map<String, Set<String>> interceptorClassNamesByComponent) {
+
+        return interceptorClassNamesByComponent.entrySet().stream()
+                .filter(entry -> entry.getKey() != null && entry.getKey().contains(EVENT_LISTENER))
+                .filter(entry -> !entry.getValue().contains(ENTITY_MANAGER_FLUSH_INTERCEPTOR_CLASS_NAME))
+                .map(Map.Entry::getKey)
+                .sorted()
+                .collect(toList());
+    }
+}

--- a/event-sourcing/subscription-manager/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/event-sourcing/subscription-manager/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,1 +1,2 @@
 uk.gov.justice.services.event.sourcing.subscription.error.startup.ErrorHandlingEnabledStatusWildflyExtension
+uk.gov.justice.services.event.sourcing.subscription.error.startup.EntityManagerFlushInterceptorPresenceVerifier

--- a/event-sourcing/subscription-manager/src/test/java/uk/gov/justice/services/event/sourcing/subscription/error/startup/EntityManagerFlushInterceptorPresenceVerifierTest.java
+++ b/event-sourcing/subscription-manager/src/test/java/uk/gov/justice/services/event/sourcing/subscription/error/startup/EntityManagerFlushInterceptorPresenceVerifierTest.java
@@ -1,0 +1,186 @@
+package uk.gov.justice.services.event.sourcing.subscription.error.startup;
+
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.justice.services.core.annotation.Component.COMMAND_HANDLER;
+import static uk.gov.justice.services.core.annotation.Component.EVENT_INDEXER;
+import static uk.gov.justice.services.core.annotation.Component.EVENT_LISTENER;
+import static uk.gov.justice.services.event.sourcing.subscription.error.startup.EntityManagerFlushInterceptorPresenceVerifier.ENTITY_MANAGER_FLUSH_INTERCEPTOR_CLASS_NAME;
+import static uk.gov.justice.services.event.sourcing.subscription.error.startup.EntityManagerFlushInterceptorPresenceVerifier.MISSING_INTERCEPTOR_MESSAGE_TEMPLATE;
+
+import uk.gov.justice.services.common.configuration.errors.event.EventErrorHandlingConfiguration;
+import uk.gov.justice.services.core.interceptor.Interceptor;
+import uk.gov.justice.services.core.interceptor.InterceptorChainEntry;
+import uk.gov.justice.services.core.interceptor.InterceptorChainEntryProvider;
+import uk.gov.justice.services.framework.utilities.cdi.CdiInstanceResolver;
+import uk.gov.justice.services.persistence.EntityManagerFlushInterceptor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.AfterDeploymentValidation;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+@ExtendWith(MockitoExtension.class)
+public class EntityManagerFlushInterceptorPresenceVerifierTest {
+
+    @Mock
+    private CdiInstanceResolver cdiInstanceResolver;
+
+    @Mock
+    private Logger logger;
+
+    @InjectMocks
+    private EntityManagerFlushInterceptorPresenceVerifier verifier;
+
+    // ---- pure decision logic ----
+
+    @Test
+    public void shouldNotFlagAnEventListenerChainThatContainsTheFlushInterceptor() {
+        final Map<String, Set<String>> byComponent = Map.of(
+                EVENT_LISTENER, Set.of(ENTITY_MANAGER_FLUSH_INTERCEPTOR_CLASS_NAME, NonFlushTestInterceptor.class.getName()));
+
+        assertThat(verifier.componentsMissingFlushInterceptor(byComponent), is(empty()));
+    }
+
+    @Test
+    public void shouldFlagAnEventListenerChainThatIsMissingTheFlushInterceptor() {
+        final Map<String, Set<String>> byComponent = Map.of(
+                EVENT_LISTENER, Set.of(NonFlushTestInterceptor.class.getName()));
+
+        assertThat(verifier.componentsMissingFlushInterceptor(byComponent), contains(EVENT_LISTENER));
+    }
+
+    @Test
+    public void shouldFlagCustomEventListenerComponentsThatAreMissingTheFlushInterceptor() {
+        final Map<String, Set<String>> byComponent = Map.of(
+                "HEARING_EVENT_LISTENER", Set.of(NonFlushTestInterceptor.class.getName()));
+
+        assertThat(verifier.componentsMissingFlushInterceptor(byComponent), contains("HEARING_EVENT_LISTENER"));
+    }
+
+    @Test
+    public void shouldNotFlagNonEventListenerComponentsEvenWithoutTheFlushInterceptor() {
+        final Map<String, Set<String>> byComponent = Map.of(
+                COMMAND_HANDLER, Set.of(NonFlushTestInterceptor.class.getName()),
+                EVENT_INDEXER, Set.of(NonFlushTestInterceptor.class.getName()));
+
+        assertThat(verifier.componentsMissingFlushInterceptor(byComponent), is(empty()));
+    }
+
+    @Test
+    public void shouldReportOnlyTheOffendingEventListenerComponents() {
+        final Map<String, Set<String>> byComponent = Map.of(
+                EVENT_LISTENER, Set.of(ENTITY_MANAGER_FLUSH_INTERCEPTOR_CLASS_NAME),
+                "HEARING_EVENT_LISTENER", Set.of(NonFlushTestInterceptor.class.getName()));
+
+        assertThat(verifier.componentsMissingFlushInterceptor(byComponent), contains("HEARING_EVENT_LISTENER"));
+    }
+
+    // ---- deployment-time behaviour ----
+
+    @Test
+    public void shouldDoNothingWhenSelfHealingIsDisabled() {
+        final AfterDeploymentValidation event = mock(AfterDeploymentValidation.class);
+        final BeanManager beanManager = mock(BeanManager.class);
+        final EventErrorHandlingConfiguration configuration = mock(EventErrorHandlingConfiguration.class);
+
+        when(cdiInstanceResolver.getInstanceOf(EventErrorHandlingConfiguration.class, beanManager)).thenReturn(configuration);
+        when(configuration.isEventStreamSelfHealingEnabled()).thenReturn(false);
+
+        verifier.afterDeploymentValidation(event, beanManager);
+
+        verify(beanManager, never()).getBeans(InterceptorChainEntryProvider.class);
+        verify(event, never()).addDeploymentProblem(any());
+        verifyNoInteractions(logger);
+    }
+
+    @Test
+    public void shouldNotFailDeploymentWhenFlushInterceptorIsPresentOnEveryEventListenerChain() {
+        final AfterDeploymentValidation event = mock(AfterDeploymentValidation.class);
+        final BeanManager beanManager = beanManagerWith(event,
+                provider(EVENT_LISTENER, EntityManagerFlushInterceptor.class, NonFlushTestInterceptor.class));
+
+        verifier.afterDeploymentValidation(event, beanManager);
+
+        verify(event, never()).addDeploymentProblem(any());
+        verifyNoInteractions(logger);
+    }
+
+    @Test
+    public void shouldFailDeploymentAndLogErrorWhenFlushInterceptorIsMissing() {
+        final AfterDeploymentValidation event = mock(AfterDeploymentValidation.class);
+        final BeanManager beanManager = beanManagerWith(event,
+                provider(EVENT_LISTENER, NonFlushTestInterceptor.class));
+
+        verifier.afterDeploymentValidation(event, beanManager);
+
+        final String expectedMessage = format(
+                MISSING_INTERCEPTOR_MESSAGE_TEMPLATE, EVENT_LISTENER, ENTITY_MANAGER_FLUSH_INTERCEPTOR_CLASS_NAME);
+
+        verify(logger).error(expectedMessage);
+
+        final ArgumentCaptor<Throwable> problemCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(event).addDeploymentProblem(problemCaptor.capture());
+        assertThat(problemCaptor.getValue(), is(instanceOf(EntityManagerFlushInterceptorMissingException.class)));
+        assertThat(problemCaptor.getValue().getMessage(), is(expectedMessage));
+    }
+
+    private BeanManager beanManagerWith(final AfterDeploymentValidation event, final InterceptorChainEntryProvider provider) {
+        final BeanManager beanManager = mock(BeanManager.class);
+        final EventErrorHandlingConfiguration configuration = mock(EventErrorHandlingConfiguration.class);
+        final Bean<?> providerBean = mock(Bean.class);
+        final CreationalContext<?> creationalContext = mock(CreationalContext.class);
+
+        when(cdiInstanceResolver.getInstanceOf(EventErrorHandlingConfiguration.class, beanManager)).thenReturn(configuration);
+        when(configuration.isEventStreamSelfHealingEnabled()).thenReturn(true);
+        when(beanManager.getBeans(InterceptorChainEntryProvider.class)).thenReturn(Set.of(providerBean));
+        doReturn(creationalContext).when(beanManager).createCreationalContext(providerBean);
+        doReturn(provider).when(beanManager).getReference(providerBean, InterceptorChainEntryProvider.class, creationalContext);
+
+        return beanManager;
+    }
+
+    @SafeVarargs
+    private InterceptorChainEntryProvider provider(final String component, final Class<? extends Interceptor>... interceptorTypes) {
+        final List<InterceptorChainEntry> entries = new ArrayList<>();
+        int priority = 1;
+        for (final Class<? extends Interceptor> interceptorType : interceptorTypes) {
+            entries.add(new InterceptorChainEntry(priority++, interceptorType));
+        }
+        return new InterceptorChainEntryProvider() {
+            @Override
+            public String component() {
+                return component;
+            }
+
+            @Override
+            public List<InterceptorChainEntry> interceptorChainTypes() {
+                return entries;
+            }
+        };
+    }
+}

--- a/event-sourcing/subscription-manager/src/test/java/uk/gov/justice/services/event/sourcing/subscription/error/startup/NonFlushTestInterceptor.java
+++ b/event-sourcing/subscription-manager/src/test/java/uk/gov/justice/services/event/sourcing/subscription/error/startup/NonFlushTestInterceptor.java
@@ -1,0 +1,17 @@
+package uk.gov.justice.services.event.sourcing.subscription.error.startup;
+
+import uk.gov.justice.services.core.interceptor.Interceptor;
+import uk.gov.justice.services.core.interceptor.InterceptorChain;
+import uk.gov.justice.services.core.interceptor.InterceptorContext;
+
+/**
+ * An arbitrary interceptor that is NOT the EntityManagerFlushInterceptor, used to populate event-listener chains
+ * that are missing the flush interceptor in verifier tests.
+ */
+public class NonFlushTestInterceptor implements Interceptor {
+
+    @Override
+    public InterceptorContext process(final InterceptorContext interceptorContext, final InterceptorChain interceptorChain) {
+        return interceptorChain.processNext(interceptorContext);
+    }
+}

--- a/event-sourcing/subscription-manager/src/test/java/uk/gov/justice/services/persistence/EntityManagerFlushInterceptor.java
+++ b/event-sourcing/subscription-manager/src/test/java/uk/gov/justice/services/persistence/EntityManagerFlushInterceptor.java
@@ -1,0 +1,19 @@
+package uk.gov.justice.services.persistence;
+
+import uk.gov.justice.services.core.interceptor.Interceptor;
+import uk.gov.justice.services.core.interceptor.InterceptorChain;
+import uk.gov.justice.services.core.interceptor.InterceptorContext;
+
+/**
+ * Test-only stand-in that shares the fully-qualified class name of the production
+ * {@code uk.gov.justice.services.persistence.EntityManagerFlushInterceptor} (which lives in the framework
+ * persistence-jpa module). subscription-manager does not depend on persistence-jpa, so there is no clash — this
+ * lets the verifier's by-class-name matching be exercised without pulling in that module.
+ */
+public class EntityManagerFlushInterceptor implements Interceptor {
+
+    @Override
+    public InterceptorContext process(final InterceptorContext interceptorContext, final InterceptorChain interceptorChain) {
+        return interceptorChain.processNext(interceptorContext);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-framework-parent-pom</artifactId>
-        <version>25.104.0-M7</version>
+        <version>25.104.0-M8</version>
     </parent>
 
     <groupId>uk.gov.justice.event-store</groupId>
@@ -42,7 +42,7 @@
 
     <properties>
         <cpp.repo.name>event-store</cpp.repo.name>
-        <framework.version>25.104.0-M3</framework.version>
+        <framework.version>25.104.0-M4</framework.version>
         <!--
             coveralls-maven-plugin:4.3.0 ships with jakarta.xml.bind-api:2.3.1 which is
             unavailable in the CI repo. Pin to 2.3.2 via plugin <dependencies> override.


### PR DESCRIPTION
## Summary

Prepares **cp-event-store** for the `25.104.0-M5` release. Two parts:

### 1. New feature — fail-fast guard for the self-healing `EntityManagerFlushInterceptor`
`EntityManagerFlushInterceptorPresenceVerifier` — a CDI `Extension` observing `AfterDeploymentValidation`. When event-stream self-healing is enabled, it verifies that **every** event-listener interceptor chain (the standard `EVENT_LISTENER` and any custom `*_EVENT_LISTENER` component) carries the `EntityManagerFlushInterceptor`, and **fails the deployment** (`addDeploymentProblem`) with a plain-English message if any is missing.

**Why it matters:** the flush interceptor forces each event-listener's DB changes to flush *within* the handler, so a DB error is caught by self-healing, recorded in the error tables, and retried. Without it, the error only surfaces at container commit — invisible to self-healing — and failing events are **silently dropped**. This interceptor has been accidentally dropped more than once (a persistence dependency reworked off the classpath; a custom event-listener component building its own chain), with no visible symptom until error capture was needed. This turns that silent gap into a hard deployment failure.

Design notes:
- Matched by **fully-qualified class name**, deliberately, so the check still runs (and fails) even when the module providing the interceptor has been dropped entirely.
- Gated on `EventErrorHandlingConfiguration.isEventStreamSelfHealingEnabled()` — a no-op when self-healing is intentionally off.
- Registered via `META-INF/services/jakarta.enterprise.inject.spi.Extension`.

Files:
- `EntityManagerFlushInterceptorPresenceVerifier` (production)
- `EntityManagerFlushInterceptorMissingException` (the deployment problem)
- Unit tests + test doubles (`NonFlushTestInterceptor`, a `persistence`-package `EntityManagerFlushInterceptor` stand-in matched by class name)

### 2. Release-chain version bumps
- parent `maven-framework-parent-pom` `25.104.0-M7` → **M8**
- `framework.version` (microservice-framework) `25.104.0-M3` → **M4**

These pull in Jackson `2.21.5` (**CVE-2026-54515**) and the `org.junit:junit-bom` import via `maven-common-bom` M6, consistent with the rest of the framework chain being released at this milestone.

## Release
Target: **`release/25.104.x`**. On merge, `cp-event-store` releases as **`25.104.0-M5`** (last of the framework chain before cake-shop validation).

CHANGELOG updated under `[25.104.0-M5]`.
